### PR TITLE
[playbook] support flexible inventory

### DIFF
--- a/clean.yml
+++ b/clean.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ inventory | default('all') }}"
   gather_facts: true
   become: true
   pre_tasks:

--- a/fetch.yml
+++ b/fetch.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ inventory | default('all') }}"
   gather_facts: true
   become: true
   pre_tasks:

--- a/main.yml
+++ b/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: "Run role as a playbook"
-  hosts: all
+  hosts: "{{ inventory | default('all') }}"
   become: true
 
   pre_tasks:

--- a/nuke.yml
+++ b/nuke.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ inventory | default('all') }}"
   gather_facts: true
   become: true
   pre_tasks:

--- a/rclone.yml
+++ b/rclone.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ inventory | default('all') }}"
   become: true
   gather_facts: true
   pre_tasks:

--- a/restart.yml
+++ b/restart.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ inventory | default('all') }}"
   gather_facts: true
   become: true
 

--- a/stop.yml
+++ b/stop.yml
@@ -1,5 +1,5 @@
 ---
-- hosts: all
+- hosts: "{{ inventory | default('all') }}"
   gather_facts: true
   become: true
 


### PR DESCRIPTION
the default host is still `all`.

with the inventory variable, we can manage individual host, such like

```
ansible-playbook -e 'inventory=<foo>' main.yml
```

Signed-off-by: Leo Chen <leo@harmony.one>